### PR TITLE
Fix test to assert heading

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+beforeAll(() => {
+  global.BroadcastChannel = class {
+    postMessage() {}
+    addEventListener() {}
+    removeEventListener() {}
+    close() {}
+  };
+});
+
+test('renders Ventilator Management System heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText(/Ventilator Management System/i);
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update `App.test.js` to render `<App />` and check for the heading
- stub `BroadcastChannel` in the test for jsdom

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6847bfed67388320ab5f6c23749758a1