### PR TITLE
Add dental SOAP note transcriber interface

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -68,6 +68,15 @@ nav {
   display: flex;
   justify-content: flex-end; /* Ensure content is aligned to the right */
   width: 100%;
+  align-items: center;
+}
+
+.nav-link {
+  margin-right: 10px;
+}
+
+.spacer {
+  flex: 1;
 }
 
 .enabled-modes-container {

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Options from './components/Options';
 import Help from './components/Help';
 import GraphPage from './components/GraphPage';
 import ParameterModal from './components/ParameterModal';
+import SoapNoteTranscriber from './components/SoapNoteTranscriber';
 import { FaArrowUp, FaArrowDown, FaInfoCircle } from 'react-icons/fa';
 
 const initialParameters = {
@@ -160,6 +161,7 @@ function AppContent() {
             <Link key={index} to="/" className="enabled-mode">{mode}</Link>
           ))}
           <div className="spacer"></div>
+          <Link to="/soap-transcriber" className="nav-link">Dental SOAP Bot</Link>
           <button onClick={handleViewGraphClick}>View Graph</button>
         </nav>
       </header>
@@ -244,6 +246,7 @@ function AppContent() {
         <Route path="/help" element={<Help />} />
         <Route path="/options" element={<Options />} />
         <Route path="/graph" element={<GraphPage parameters={parameters} />} />
+        <Route path="/soap-transcriber" element={<SoapNoteTranscriber />} />
       </Routes>
       {modalParam && (
         <ParameterModal 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,24 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+class MockBroadcastChannel {
+  constructor() {}
+  postMessage() {}
+  close() {}
+  addEventListener() {}
+  removeEventListener() {}
+}
+
+beforeAll(() => {
+  global.BroadcastChannel = MockBroadcastChannel;
+});
+
+afterAll(() => {
+  delete global.BroadcastChannel;
+});
+
+test('renders application header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /ventilator management system/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/src/components/SoapNoteTranscriber.css
+++ b/src/components/SoapNoteTranscriber.css
@@ -1,0 +1,255 @@
+.soap-transcriber {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  color: var(--text-light);
+  background-color: var(--panel-background);
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  max-width: 1100px;
+  margin: 1.5rem auto;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+}
+
+.soap-transcriber__intro h2 {
+  margin-top: 0;
+  font-size: 1.8rem;
+}
+
+.soap-transcriber__intro p {
+  margin: 0.5rem 0 0;
+  color: rgba(255, 255, 255, 0.75);
+  line-height: 1.6;
+}
+
+.soap-transcriber__metadata h3,
+.soap-transcriber__transcript h3,
+.soap-transcriber__summary h3,
+.soap-transcriber__note h3,
+.soap-transcriber__actions-table h3,
+.soap-transcriber__preview h3 {
+  margin-top: 0;
+}
+
+.soap-transcriber__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.soap-transcriber__grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.soap-transcriber__grid input,
+.soap-transcriber textarea {
+  background-color: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  padding: 0.75rem;
+  color: var(--text-light);
+  font-size: 0.95rem;
+}
+
+.soap-transcriber__grid input:focus,
+.soap-transcriber textarea:focus {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 0;
+}
+
+.soap-transcriber__full-width {
+  grid-column: 1 / -1;
+}
+
+.soap-transcriber__transcript-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.soap-transcriber__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.soap-transcriber button {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  font-weight: 600;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.soap-transcriber button.primary {
+  background-color: var(--primary-color);
+  color: var(--text-light);
+}
+
+.soap-transcriber button.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.soap-transcriber button.ghost {
+  background-color: transparent;
+  color: var(--text-light);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.soap-transcriber textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 150px;
+}
+
+.soap-transcriber__hint {
+  font-size: 0.85rem;
+  margin: 0.4rem 0 0;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.soap-transcriber__summary {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.soap-transcriber__insights ul,
+.soap-transcriber__metrics ul,
+.soap-transcriber__risks ul {
+  list-style: disc;
+  padding-left: 1.2rem;
+  margin: 0.6rem 0 0;
+}
+
+.soap-transcriber__risks {
+  background: rgba(231, 76, 60, 0.15);
+  border: 1px solid rgba(231, 76, 60, 0.4);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.soap-transcriber__note-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.soap-transcriber__sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.soap-transcriber__section-card {
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.soap-transcriber__section-card header h4 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.soap-transcriber__section-card header p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.soap-transcriber__actions-table {
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+.soap-transcriber__table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.soap-transcriber__table-row {
+  display: grid;
+  grid-template-columns: 0.9fr 3fr 0.8fr;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.6rem 0.8rem;
+  border-radius: 8px;
+  background-color: rgba(0, 0, 0, 0.2);
+}
+
+.soap-transcriber__table-row--header {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.priority {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.priority--high {
+  background: rgba(231, 76, 60, 0.25);
+  color: #ff928a;
+}
+
+.priority--routine {
+  background: rgba(46, 204, 113, 0.25);
+  color: #9ef3c3;
+}
+
+.soap-transcriber__preview pre {
+  background-color: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (max-width: 768px) {
+  .soap-transcriber {
+    margin: 1rem;
+    padding: 1.25rem;
+  }
+
+  .soap-transcriber__transcript-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .soap-transcriber__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .soap-transcriber button {
+    width: auto;
+  }
+
+  .soap-transcriber__table-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/SoapNoteTranscriber.js
+++ b/src/components/SoapNoteTranscriber.js
@@ -1,0 +1,506 @@
+import React, { useMemo, useState } from 'react';
+import './SoapNoteTranscriber.css';
+
+const SECTION_META = [
+  {
+    key: 'subjective',
+    title: 'Subjective',
+    helper: 'Patient-reported concerns, history, and symptoms discussed during the meeting.',
+  },
+  {
+    key: 'objective',
+    title: 'Objective',
+    helper: 'Clinical observations, diagnostics, and measurable findings shared by the team.',
+  },
+  {
+    key: 'assessment',
+    title: 'Assessment',
+    helper: 'Diagnostic impressions, problem lists, and professional interpretations.',
+  },
+  {
+    key: 'plan',
+    title: 'Plan',
+    helper: 'Proposed treatments, follow-ups, tasks, and responsibilities agreed upon.',
+  },
+];
+
+const KEYWORD_LIBRARY = {
+  subjective: [
+    'reports',
+    'states',
+    'notes',
+    'complains',
+    'pain',
+    'sensitivity',
+    'history',
+    'concern',
+    'fear',
+    'anxious',
+    'feels',
+    'symptom',
+    'chief complaint',
+  ],
+  objective: [
+    'exam',
+    'observed',
+    'findings',
+    'pocket',
+    'mm',
+    'probe',
+    'radiograph',
+    'x-ray',
+    'imaging',
+    'visual',
+    'charting',
+    'vital',
+    'gum',
+    'tissue',
+    'lesion',
+    'mobility',
+    'measure',
+    'calculus',
+  ],
+  assessment: [
+    'diagnosis',
+    'assessment',
+    'decay',
+    'caries',
+    'periodontal',
+    'gingivitis',
+    'evaluation',
+    'likely',
+    'suspect',
+    'indicates',
+    'differential',
+    'risk',
+    'classification',
+  ],
+  plan: [
+    'plan',
+    'recommend',
+    'schedule',
+    'follow-up',
+    'follow up',
+    'next visit',
+    'will',
+    'proceed',
+    'start',
+    'implement',
+    'prescribe',
+    'deliver',
+    'coordinate',
+    'refer',
+    'order',
+  ],
+};
+
+const RISK_KEYWORDS = ['urgent', 'infection', 'abscess', 'swelling', 'uncontrolled', 'bleeding', 'emergency'];
+const ACTION_KEYWORDS = ['schedule', 'call', 'order', 'submit', 'prepare', 'follow', 'coordinate', 'arrange', 'review'];
+
+const defaultMetadata = {
+  patientName: '',
+  meetingDate: '',
+  provider: '',
+  hygienist: '',
+  meetingFocus: '',
+};
+
+const splitSentences = (text) =>
+  text
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 3);
+
+const assignSection = (sentence) => {
+  const lower = sentence.toLowerCase();
+
+  const matches = Object.entries(KEYWORD_LIBRARY).map(([section, keywords]) => ({
+    section,
+    score: keywords.reduce((acc, keyword) => (lower.includes(keyword) ? acc + 1 : acc), 0),
+  }));
+
+  const bestMatch = matches.reduce(
+    (prev, current) => (current.score > prev.score ? current : prev),
+    { section: 'objective', score: 0 }
+  );
+
+  if (bestMatch.score > 0) {
+    return bestMatch.section;
+  }
+
+  if (lower.includes('plan to') || lower.includes('will ') || lower.includes('need to')) {
+    return 'plan';
+  }
+
+  if (lower.includes('reports') || lower.includes('pain') || lower.includes('complain')) {
+    return 'subjective';
+  }
+
+  return 'objective';
+};
+
+const detectActionOwner = (sentence) => {
+  const ownerMatch = sentence.match(/(?:Dr\.?\s+[A-Z][a-z]+|[A-Z][a-z]+(?=\s+(?:will|to)))/);
+  return ownerMatch ? ownerMatch[0] : 'Team';
+};
+
+const analyseTranscript = (text) => {
+  const sentences = splitSentences(text);
+  const sections = {
+    subjective: [],
+    objective: [],
+    assessment: [],
+    plan: [],
+  };
+  const actionItems = [];
+  const riskFlags = [];
+
+  sentences.forEach((sentence) => {
+    const trimmed = sentence.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const section = assignSection(trimmed);
+    sections[section].push(trimmed);
+
+    const lower = trimmed.toLowerCase();
+
+    if (RISK_KEYWORDS.some((keyword) => lower.includes(keyword))) {
+      riskFlags.push(trimmed);
+    }
+
+    if (ACTION_KEYWORDS.some((keyword) => lower.includes(keyword)) || section === 'plan') {
+      actionItems.push({
+        owner: detectActionOwner(trimmed),
+        detail: trimmed,
+        priority: lower.includes('urgent') || lower.includes('asap') ? 'High' : 'Routine',
+      });
+    }
+  });
+
+  const words = text
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+
+  return {
+    sections,
+    actionItems,
+    riskFlags,
+    metrics: {
+      sentenceCount: sentences.length,
+      wordCount: words.length,
+      estimatedDuration: words.length ? Math.round((words.length / 150) * 60) : 0,
+    },
+  };
+};
+
+const buildNoteText = (metadata, sectionText) => {
+  const header = [
+    metadata.patientName ? `Patient: ${metadata.patientName}` : null,
+    metadata.meetingDate ? `Date: ${metadata.meetingDate}` : null,
+    metadata.provider ? `Provider: ${metadata.provider}` : null,
+    metadata.hygienist ? `Hygienist/Assistant: ${metadata.hygienist}` : null,
+    metadata.meetingFocus ? `Focus: ${metadata.meetingFocus}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const body = SECTION_META.map(({ key, title }) => {
+    const content = sectionText[key]?.trim() || '•';
+    return `${title}:\n${content}`;
+  }).join('\n\n');
+
+  return [header, body].filter(Boolean).join('\n\n');
+};
+
+const SoapNoteTranscriber = () => {
+  const [metadata, setMetadata] = useState(defaultMetadata);
+  const [transcript, setTranscript] = useState('');
+  const [analysis, setAnalysis] = useState(null);
+  const [sectionDrafts, setSectionDrafts] = useState(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleMetadataChange = (field, value) => {
+    setMetadata((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const handleGenerate = () => {
+    if (!transcript.trim()) {
+      setAnalysis(null);
+      setSectionDrafts(null);
+      return;
+    }
+
+    const result = analyseTranscript(transcript);
+    setAnalysis(result);
+    setSectionDrafts(
+      SECTION_META.reduce(
+        (acc, { key }) => ({
+          ...acc,
+          [key]: result.sections[key].length ? `• ${result.sections[key].join('\n• ')}` : '',
+        }),
+        {}
+      )
+    );
+    setCopied(false);
+  };
+
+  const handleClear = () => {
+    setTranscript('');
+    setAnalysis(null);
+    setSectionDrafts(null);
+    setCopied(false);
+  };
+
+  const quickInsights = useMemo(() => {
+    if (!analysis) {
+      return [];
+    }
+
+    const insights = [];
+
+    if (analysis.sections.subjective.length) {
+      insights.push(`Primary concern: ${analysis.sections.subjective[0]}`);
+    }
+
+    if (analysis.sections.assessment.length) {
+      insights.push(`Working diagnosis: ${analysis.sections.assessment[analysis.sections.assessment.length - 1]}`);
+    }
+
+    if (analysis.actionItems.length) {
+      insights.push(`Action items captured: ${analysis.actionItems.length}`);
+    }
+
+    if (analysis.riskFlags.length) {
+      insights.push('Attention: Potential risk factors flagged in conversation.');
+    }
+
+    return insights;
+  }, [analysis]);
+
+  const compiledNote = useMemo(() => {
+    if (!sectionDrafts) {
+      return '';
+    }
+
+    return buildNoteText(metadata, sectionDrafts);
+  }, [metadata, sectionDrafts]);
+
+  const handleCopy = async () => {
+    if (!compiledNote) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(compiledNote);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch (error) {
+      console.error('Clipboard copy failed', error);
+      setCopied(false);
+    }
+  };
+
+  const handleSectionChange = (key, value) => {
+    setSectionDrafts((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+    setCopied(false);
+  };
+
+  return (
+    <div className="soap-transcriber">
+      <div className="soap-transcriber__intro">
+        <h2>Dentist SOAP Note Transcriber</h2>
+        <p>
+          Transform internal meeting transcripts into structured SOAP notes for dental teams. Paste a
+          transcript, capture key metadata, and generate an editable note ready for your charting
+          system.
+        </p>
+      </div>
+
+      <section className="soap-transcriber__metadata">
+        <h3>Encounter Metadata</h3>
+        <div className="soap-transcriber__grid">
+          <label>
+            <span>Patient name</span>
+            <input
+              type="text"
+              value={metadata.patientName}
+              onChange={(event) => handleMetadataChange('patientName', event.target.value)}
+              placeholder="e.g., Jordan Matthews"
+            />
+          </label>
+          <label>
+            <span>Meeting date</span>
+            <input
+              type="date"
+              value={metadata.meetingDate}
+              onChange={(event) => handleMetadataChange('meetingDate', event.target.value)}
+            />
+          </label>
+          <label>
+            <span>Lead provider</span>
+            <input
+              type="text"
+              value={metadata.provider}
+              onChange={(event) => handleMetadataChange('provider', event.target.value)}
+              placeholder="e.g., Dr. Hwang"
+            />
+          </label>
+          <label>
+            <span>Hygienist / Assistant</span>
+            <input
+              type="text"
+              value={metadata.hygienist}
+              onChange={(event) => handleMetadataChange('hygienist', event.target.value)}
+              placeholder="e.g., Morgan (RDH)"
+            />
+          </label>
+          <label className="soap-transcriber__full-width">
+            <span>Meeting focus</span>
+            <input
+              type="text"
+              value={metadata.meetingFocus}
+              onChange={(event) => handleMetadataChange('meetingFocus', event.target.value)}
+              placeholder="e.g., Pre-op coordination for implant on #14"
+            />
+          </label>
+        </div>
+      </section>
+
+      <section className="soap-transcriber__transcript">
+        <div className="soap-transcriber__transcript-header">
+          <h3>Transcript</h3>
+          <div className="soap-transcriber__actions">
+            <button type="button" onClick={handleGenerate} className="primary">
+              Generate SOAP note
+            </button>
+            <button type="button" onClick={handleClear} className="ghost">
+              Clear
+            </button>
+          </div>
+        </div>
+        <textarea
+          value={transcript}
+          onChange={(event) => setTranscript(event.target.value)}
+          placeholder="Paste or type the team meeting transcript here..."
+          rows={10}
+        />
+        <p className="soap-transcriber__hint">
+          Tip: Include speaker names (e.g., “Dr. Singh: We should schedule a follow-up...”) to help the
+          assistant assign action items.
+        </p>
+      </section>
+
+      {analysis && (
+        <section className="soap-transcriber__summary">
+          <div className="soap-transcriber__insights">
+            <h3>Quick insights</h3>
+            {quickInsights.length ? (
+              <ul>
+                {quickInsights.map((insight, index) => (
+                  <li key={index}>{insight}</li>
+                ))}
+              </ul>
+            ) : (
+              <p>No specific highlights detected. Review the sections below.</p>
+            )}
+          </div>
+
+          <div className="soap-transcriber__metrics">
+            <h4>Transcript metrics</h4>
+            <ul>
+              <li>
+                Sentences processed: <strong>{analysis.metrics.sentenceCount}</strong>
+              </li>
+              <li>
+                Word count: <strong>{analysis.metrics.wordCount}</strong>
+              </li>
+              <li>
+                Estimated duration (150 wpm): <strong>{analysis.metrics.estimatedDuration} seconds</strong>
+              </li>
+            </ul>
+          </div>
+
+          {analysis.riskFlags.length > 0 && (
+            <div className="soap-transcriber__risks">
+              <h4>Risk alerts</h4>
+              <ul>
+                {analysis.riskFlags.map((flag, index) => (
+                  <li key={index}>{flag}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+      )}
+
+      {analysis && (
+        <section className="soap-transcriber__note">
+          <div className="soap-transcriber__note-header">
+            <h3>Editable SOAP note</h3>
+            <button type="button" onClick={handleCopy} disabled={!compiledNote} className="primary">
+              {copied ? 'Copied to clipboard!' : 'Copy full note'}
+            </button>
+          </div>
+          <div className="soap-transcriber__sections">
+            {SECTION_META.map(({ key, title, helper }) => (
+              <div key={key} className="soap-transcriber__section-card">
+                <header>
+                  <h4>{title}</h4>
+                  <p>{helper}</p>
+                </header>
+                <textarea
+                  value={sectionDrafts?.[key] || ''}
+                  onChange={(event) => handleSectionChange(key, event.target.value)}
+                  rows={6}
+                  placeholder={`Add ${title.toLowerCase()} details here...`}
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {analysis && analysis.actionItems.length > 0 && (
+        <section className="soap-transcriber__actions-table">
+          <h3>Action items for follow-up</h3>
+          <div className="soap-transcriber__table">
+            <div className="soap-transcriber__table-row soap-transcriber__table-row--header">
+              <div>Owner</div>
+              <div>Detail</div>
+              <div>Priority</div>
+            </div>
+            {analysis.actionItems.map((item, index) => (
+              <div key={`${item.detail}-${index}`} className="soap-transcriber__table-row">
+                <div>{item.owner}</div>
+                <div>{item.detail}</div>
+                <div>
+                  <span className={`priority priority--${item.priority.toLowerCase()}`}>
+                    {item.priority}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {compiledNote && (
+        <section className="soap-transcriber__preview">
+          <h3>Note preview</h3>
+          <pre>{compiledNote}</pre>
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default SoapNoteTranscriber;


### PR DESCRIPTION
## Summary
- add a dentist-focused SOAP note transcriber that analyzes meeting transcripts into editable sections, metrics, and action items
- expose the tool via a new navigation link, update styling hooks, and keep the existing ventilator dashboard routes intact
- mock `BroadcastChannel` in the app test to stabilize the suite after introducing the new page

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cb713855f08320be74509ef695a08e